### PR TITLE
fix onClick bug, small changes per discord comment (except font color…

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -106,7 +106,10 @@ function TopBar(this: any, props: any) {
               <Button
                 size="small"
                 color="info"
-                onClick={() => getPrevious()}
+                onClick={() => {
+                  getPrevious()
+                  props.handleDayClickBar(0)
+                }}
                 style={{ fontSize: '32px', color: 'black' }}
               >
                 &lt;
@@ -121,7 +124,10 @@ function TopBar(this: any, props: any) {
               <Button
                 size="small"
                 color="info"
-                onClick={() => getFollowing()}
+                onClick={() => {
+                  getFollowing()
+                  props.handleDayClickBar(0)
+                }}
                 style={{ fontSize: '32px', color: 'black' }}
               >
                 &gt;

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -27,7 +27,7 @@ const Calendar = (props: CalendarProps) => {
       color="black"
       flex={1}
       sx={{ height: 'calc(100vh - 64px)' }}
-      border={1}
+      border={0}
     >
       {renderCalendar()}
     </Box>

--- a/src/components/calendar/Day.tsx
+++ b/src/components/calendar/Day.tsx
@@ -37,8 +37,8 @@ const Day = (props: DayProps) => {
           onClick={() => props.handleDayClick(props.day)}
           size={props.isMonthView ? 'large' : 'small'}
           style={{
-            fontSize: props.isMonthView ? '28px' : '100%',
-            color: 'black'
+            fontSize: props.isMonthView ? '28px' : '85%',
+            color: '#4D4D4D'
           }}
         >
           {props.day.toString()}

--- a/src/components/calendar/Year.tsx
+++ b/src/components/calendar/Year.tsx
@@ -39,7 +39,7 @@ const Year = (props: YearProps) => {
   }
 
   const renderMonth = (month: string) => {
-    const daysOfWeek = ['Su', 'M', 'T', 'W', 'Th', 'F', 'S']
+    const daysOfWeek = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
     const monthNumber = months.indexOf(month)
 
     return (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,6 +16,7 @@ body {
   max-width: 100vw;
   overflow-x: hidden;
   height: max-content;
+  background-color: #fff;
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
…/size)
Before, clicking a date and then pressing the button to change the month/year would cause the menu to change/delete an event to popup.  I think I fixed it but I'm not too sure if I fixed it correctly.

Also made changes based on Julia's comments
- get the code to resize to less columns when the window becomes more narrow (pretty easy with grid, you can set different breakpoints for size ). That way the months will stay the same size so it doesnt mess up once we start putting symbols on top. Google calendar also does this if you wanna check different screen sizes 
- when resizing vertically, a line shows at the bottom for smaller windows (year view)
- change sunday and thursday to S T (if it doesnt break the code)

I didn't do this change yet
- smaller font size ; update colours to #4F4F4F or #4D4D4D for fonts and lines (maybe lighter for lines)